### PR TITLE
Sync core con notifier 1.1 y Fix en comentarios generales

### DIFF
--- a/db-api/comment.js
+++ b/db-api/comment.js
@@ -50,7 +50,8 @@ exports.reply = function reply (query, reply) {
 exports.updateDecorations = async function updateDecorations (version, decorations) {
   let query = {
     version: version,
-    resolved: false
+    resolved: false,
+    field: 'articles'
   }
   let decorationsMap = {}
   decorations.forEach((deco) => {

--- a/services/notifier.js
+++ b/services/notifier.js
@@ -4,29 +4,32 @@ const log = require('./logger')
 
 const http = axios.create()
 
-exports.sendCommentNotification = async ({ type, comment, participant, accountable, title }) => {
+exports.sendCommentNotification = async (notificationType, commentId) => {
   let payload = {
-    'type': type,
-    'info': {
-      'to': participant.email,
-      'document': {
-        'title': title,
-        'participant': participant,
-        'accountable': accountable,
-        'comment': comment
-      }
-    }
+    type: notificationType,
+    comment: commentId
   }
-  http.post(NOTIFIER_URL, payload).then((response) => {
-    log.info(response.data.message, {
-      type: type,
-      to: participant.email
-    })
+  http.post(`${NOTIFIER_URL}/send-email`, payload).then((response) => {
+    log.info(response.data.message, payload)
   }).catch((error) => {
     log.error('ERROR Sending Email', {
-      type: type,
-      to: participant.email,
-      meta: error.message
+      meta: payload,
+      message: error.message
+    })
+  })
+}
+
+exports.setDocumentClosesNotification = async (documentId, closingDate) => {
+  let payload = {
+    id: documentId,
+    closingDate
+  }
+  http.post(`${NOTIFIER_URL}/set-document-closes`, payload).then((response) => {
+    log.info(response.data.message, payload)
+  }).catch((error) => {
+    log.error('ERROR Setting document closes event', {
+      error: error.message,
+      meta: payload
     })
   })
 }


### PR DESCRIPTION
- Se arreglo lo de los comentarios generales, sin querer en `udpateDecorations` la query se ejecutaba de forma de que no solo traia los comentarios de los articulos pero tambien las de la fundation.
- Sincronizado los cambios de notifier en el core. Se adapto los payload ya existentes y se crearon las notificaciones para el cierre del documento.