### PR TITLE
Ready for 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+**1.5.0**
+
+- Agregado "closed" atributo a todos los documentos que devuelve el API endpoint `/my-documents` 
+
+_Compatible con leyesabiertas-notifier:1.3.0 y leyesabiertas-web:1.5.0_
+
 **1.4.0**
 
 - DERLA-33 Nuevo feature: Poder navegar por las versiones historicas del documento (Agregado obtener la version de un documento)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **1.5.0**
 
+- Ahora `GET /documents` cambio su forma de obtener y paginar los resultados que obtiene. En coordinacion con el front, ahora los resultados se paginan, y se fuerza el orden de que en primer lugar aparecen las propuestas abiertas, y luego, las cerradas. Se descarta entonces el uso de "mongoose-paginate" para este caso, lamentablemente el paquete limita mucho llevar a cabo queries complejas.
 - Agregado "closed" atributo a todos los documentos que devuelve el API endpoint `/my-documents` 
 
 _Compatible con leyesabiertas-notifier:1.3.0 y leyesabiertas-web:1.5.0_

--- a/api/document.js
+++ b/api/document.js
@@ -33,7 +33,7 @@ router.route('/')
   /**
    * @api {get} /documents List
    * @apiName getDocuments
-   * @apiDescription Returns a paginated list of -published- documents
+   * @apiDescription Returns a paginated list of -published- documents => querystring = page,limit,closed(null,false,true),created(ASC,DESC)
    * @apiGroup Document
    */
   .get(
@@ -43,24 +43,48 @@ router.route('/')
         let sort = null
         if (req.query) {
           sort = {}
-          sort.createdAt = req.query.created === 'ASC' ? '1' : '-1'
+          sort.createdAt = req.query.created === 'ASC' ? 1 : -1
         }
-        // If it is null, just show the published documents
-        results = await Document.list({ published: true }, {
-          limit: req.query.limit,
-          page: req.query.page,
-          sort
-        })
+        let paginate = {
+          limit: req.query.limit || 10,
+          page: req.query.page || 1
+        }
+        results = await Document.retrieve({ published: true }, sort)
         let today = new Date()
-        results.docs.forEach((doc) => {
+        results.forEach((doc) => {
           doc.closed = today > new Date(doc.currentVersion.content.closingDate)
         })
+        if (req.query.closed !== 'null') {
+          results = results.filter((doc) => {
+            return doc.closed === (req.query.closed === 'true')
+          })
+        } else {
+          let arrOpened = results.filter((doc) => {
+            return doc.closed === false
+          })
+          let arrClosed = results.filter((doc) => {
+            return doc.closed === true
+          })
+          results = arrOpened.concat(arrClosed)
+          // results = results.sort(function (x, y) {
+          //   // return (x === y)? 0 : x? -1 : 1;
+          //   return (x.closed === y.closed) ? 0 : x.closed ? 1 : -1
+          // })
+        }
+        let auxOne = parseInt(results.length / paginate.limit)
+        let auxTwo = results.length % paginate.limit
+        if (auxTwo) {
+          auxOne++
+        }
+        let cantTotal = results.length
+        let finalArr = results.splice(((paginate.page - 1) * paginate.limit), paginate.limit)
         res.status(status.OK).json({
-          results: results.docs,
+          results: finalArr,
           pagination: {
-            count: results.total,
-            page: results.page,
-            limit: results.limit
+            count: cantTotal,
+            page: paginate.page,
+            pages: auxOne,
+            limit: paginate.limit
           }
         })
       } catch (err) {
@@ -313,7 +337,7 @@ router.route('/:id/version/:version')
         next(err)
       }
     }
- )
+  )
 
 router.route('/:id/comments')
   /**

--- a/api/document.js
+++ b/api/document.js
@@ -121,6 +121,10 @@ router.route('/my-documents')
           limit: req.query.limit,
           page: req.query.page
         })
+        let today = new Date()
+        results.docs.forEach((doc) => {
+          doc.closed = today > new Date(doc.currentVersion.content.closingDate)
+        })
         res.status(status.OK).json({
           results: results.docs,
           pagination: {

--- a/db-api/document.js
+++ b/db-api/document.js
@@ -53,13 +53,20 @@ exports.get = async function get (query) {
   return document
 }
 
+exports.retrieve = async function get (query, sort) {
+  let theSort = sort || {}
+  console.log(theSort)
+  let document = await Document.find(query).populate({ path: 'author', select: dbUser.exposeAll(false) }).populate('currentVersion').sort(theSort).lean()
+  return document
+}
+
 // List documents
 exports.list = async function list (query, { limit, page, sort }) {
   let optionsPaginate = {}
   optionsPaginate.limit = limit
   optionsPaginate.page = page
   optionsPaginate.lean = true
-  optionsPaginate.populate = [{ path: 'author', select: dbUser.exposeAll(false) }, 'currentVersion']
+  optionsPaginate.populate = [{ path: 'author', select: dbUser.exposeAll(false) }, {path: 'currentVersion'}]
   if (sort) {
     optionsPaginate.sort = sort
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/DemocracyOS/core.git"


### PR DESCRIPTION
- Ahora `GET /documents` cambio su forma de obtener y paginar los resultados que obtiene. En coordinacion con el front, ahora los resultados se paginan, y se fuerza el orden de que en primer lugar aparecen las propuestas abiertas, y luego, las cerradas. Se descarta entonces el uso de "mongoose-paginate" para este caso, lamentablemente el paquete limita mucho llevar a cabo queries complejas.
- Agregado "closed" atributo a todos los documentos que devuelve el API endpoint `/my-documents` 

Compatible con:
- `leyesabiertas-web:1.5.0`
- `leyesabiertas-notifier:1.5.0`
